### PR TITLE
Add rockchip compile dirs add gstreamer

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,11 +1,13 @@
-CROSS_COMPILE	?= 
-ARCH		?= x86
-KERNEL_DIR	?= /usr/src/linux
+CROSS_COMPILE	?= /opt/rockchip/output/host/bin/arm-buildroot-linux-gnueabihf-gcc
+ARCH		?= armv7l
+KERNEL_DIR	?= /opt/rockchip/output/host/arm-buildroot-linux-gnueabihf/sysroot/usr
 
-CC		:= $(CROSS_COMPILE)gcc
-KERNEL_INCLUDE	:= -I$(KERNEL_DIR)/include -I$(KERNEL_DIR)/arch/$(ARCH)/include
-CFLAGS		:= -W -Wall -g $(KERNEL_INCLUDE)
-LDFLAGS		:= -g
+CC		:= $(CROSS_COMPILE)
+KERNEL_INCLUDE	:= -I$(KERNEL_DIR)/include -I$(KERNEL_DIR)/arch/$(ARCH)/include \
+					-I$(KERNEL_DIR)/include/gstreamer-1.0 -I$(KERNEL_DIR)/include/glib-2.0 \
+					-I$(KERNEL_DIR)/lib/glib-2.0/include
+CFLAGS		:= -W -Wall -g $(KERNEL_INCLUDE) $(pkg-config --cflags)
+LDFLAGS		:= -g $(pkg-config --libs gstreamer-1.0) -lgstreamer-1.0 -lgobject-2.0 -lglib-2.0 -lgstapp-1.0
 
 all: uvc-gadget
 

--- a/Readme.md
+++ b/Readme.md
@@ -5,9 +5,9 @@
     ./uvc-gadget -f 1 -r 1 -v <v4l2_video_node> -u <uvc_video_node>
 
 
-**Upstream Latest Version: http://git.ideasonboard.org/uvc-gadget.git**
-
 ## uvc-gadget
+
+**Upstream Latest Version: http://git.ideasonboard.org/uvc-gadget.git**
 
 **Upstream project [uvc-gadget](http://git.ideasonboard.org/uvc-gadget.git) has been updated and continuous maintenance**
 

--- a/Readme.md
+++ b/Readme.md
@@ -1,3 +1,10 @@
+## How to use for Rockchip
+1. Build on host machine:
+    make
+2. Run uvc-gadget executable on Rockhip:
+    ./uvc-gadget -f 1 -r 1 -v <v4l2_video_node> -u <uvc_video_node>
+
+
 **Upstream Latest Version: http://git.ideasonboard.org/uvc-gadget.git**
 
 ## uvc-gadget

--- a/uvc-gadget.c
+++ b/uvc-gadget.c
@@ -2093,12 +2093,13 @@ static void usage(const char *argv0)
 
 GstElement* gst_init_appsrc_pipeline()
 {
-    GstElement *pipeline, *appsrc, *queue, *rtppay, *udpsink;
+    GstElement *pipeline, *appsrc, *jpegparse, *queue, *rtppay, *udpsink;
     GstBus *bus;
 
     /* setup appsrc pipeline */
     pipeline = gst_pipeline_new ("pipeline");
     appsrc = gst_element_factory_make ("appsrc", "source");
+    jpegparse = gst_element_factory_make ("jpegparse", "parse");
     queue = gst_element_factory_make("queue", NULL);
     rtppay = gst_element_factory_make ("rtpjpegpay", "payload");
     udpsink = gst_element_factory_make ("udpsink", "udp_sink");
@@ -2111,8 +2112,8 @@ GstElement* gst_init_appsrc_pipeline()
                         "height", G_TYPE_INT, 720,
                         "framerate", GST_TYPE_FRACTION, 30, 1,
                         NULL), NULL);
-    gst_bin_add_many (GST_BIN (pipeline), appsrc, queue, rtppay, udpsink, NULL);
-    gst_element_link_many (appsrc, queue, rtppay, udpsink, NULL);
+    gst_bin_add_many (GST_BIN (pipeline), appsrc, jpegparse, queue, rtppay, udpsink, NULL);
+    gst_element_link_many (appsrc, jpegparse, queue, rtppay, udpsink, NULL);
 
     /* setup appsrc */
     g_object_set (G_OBJECT (appsrc),
@@ -2125,7 +2126,7 @@ GstElement* gst_init_appsrc_pipeline()
     g_object_set(G_OBJECT(queue), "max-size-time", 500 * GST_MSECOND, NULL);
 
     /* setup udpsink */
-    g_object_set(G_OBJECT(udpsink), "clients", "192.168.2.169:1234", NULL);
+    g_object_set(G_OBJECT(udpsink), "clients", "192.168.2.124:1234", NULL);
     g_object_set(G_OBJECT(udpsink), "sync", TRUE, NULL);
 
     bus = gst_pipeline_get_bus (GST_PIPELINE (pipeline));

--- a/uvc-gadget.c
+++ b/uvc-gadget.c
@@ -36,6 +36,9 @@
 #include <linux/usb/video.h>
 #include <linux/videodev2.h>
 
+#include <gst/gst.h>
+#include <gst/app/gstappsrc.h>
+
 #include "uvc.h"
 
 /* Enable debug prints. */

--- a/uvc-gadget.c
+++ b/uvc-gadget.c
@@ -88,6 +88,9 @@
 #define PU_BRIGHTNESS_STEP_SIZE 1
 #define PU_BRIGHTNESS_DEFAULT_VAL 127
 
+/* gst constants */
+const gchar* UDP_CLIENT_IP_ADDR = "192.168.2.124:1234";
+
 /* ---------------------------------------------------------------------------
  * Generic stuff
  */
@@ -514,8 +517,8 @@ static int v4l2_process_data(struct v4l2_device *dev, GstElement *pipeline)
     dev->dqbuf_count++;
 
     /* Push v4l2 buffer data to gstreamer appsrc */
-    gstbuf = gst_buffer_new_allocate(NULL, dev->mem[0].length, NULL);
-    gst_buffer_fill(gstbuf, 0, dev->mem[0].start, dev->mem[0].length);
+    gstbuf = gst_buffer_new_allocate(NULL, dev->mem[vbuf.index].length, NULL);
+    gst_buffer_fill(gstbuf, 0, dev->mem[vbuf.index].start, vbuf.bytesused);
     appsrc = gst_bin_get_by_name (GST_BIN (pipeline), "source");
     g_signal_emit_by_name (appsrc, "push-buffer", gstbuf, &gstret);
     gst_object_unref (appsrc);
@@ -2126,7 +2129,7 @@ GstElement* gst_init_appsrc_pipeline()
     g_object_set(G_OBJECT(queue), "max-size-time", 500 * GST_MSECOND, NULL);
 
     /* setup udpsink */
-    g_object_set(G_OBJECT(udpsink), "clients", "192.168.2.124:1234", NULL);
+    g_object_set(G_OBJECT(udpsink), "clients", UDP_CLIENT_IP_ADDR, NULL);
     g_object_set(G_OBJECT(udpsink), "sync", TRUE, NULL);
 
     bus = gst_pipeline_get_bus (GST_PIPELINE (pipeline));

--- a/uvc-gadget.c
+++ b/uvc-gadget.c
@@ -62,6 +62,8 @@
 #define ARRAY_SIZE(a) ((sizeof(a) / sizeof(a[0])))
 #define pixfmtstr(x) (x) & 0xff, ((x) >> 8) & 0xff, ((x) >> 16) & 0xff, ((x) >> 24) & 0xff
 
+#define UNUSED(x) (void)(x)
+
 /*
  * The UVC webcam gadget kernel driver (g_webcam.ko) supports changing
  * the Brightness attribute of the Processing Unit (PU). by default. If
@@ -237,6 +239,36 @@ struct uvc_device {
 
 /* forward declarations */
 static int uvc_video_stream(struct uvc_device *dev, int enable);
+
+
+static gboolean gst_bus_callback(GstBus * bus, GstMessage * message, gpointer data)
+{
+    UNUSED(bus);
+    UNUSED(data);
+
+    switch (GST_MESSAGE_TYPE (message)) {
+    case GST_MESSAGE_ERROR:{
+        GError *err;
+        gchar *debug;
+
+        gst_message_parse_error (message, &err, &debug);
+        g_error ("Error received from element %s: %s\n",
+                    GST_OBJECT_NAME (message->src), err->message);
+        g_print ("Debugging information: %s\n", debug ? debug : "none");
+        g_error_free (err);
+        g_free (debug);
+        break;
+    }
+    case GST_MESSAGE_EOS:
+        /* end-of-stream */
+        break;
+    default:
+        /* unhandled message */
+        break;
+    }
+
+    return TRUE;
+}
 
 /* ---------------------------------------------------------------------------
  * V4L2 streaming related
@@ -442,11 +474,14 @@ static int v4l2_qbuf(struct v4l2_device *dev)
     return ret;
 }
 
-static int v4l2_process_data(struct v4l2_device *dev)
+static int v4l2_process_data(struct v4l2_device *dev, GstElement *pipeline)
 {
     int ret;
     struct v4l2_buffer vbuf;
     struct v4l2_buffer ubuf;
+    GstBuffer *gstbuf;
+    GstElement* appsrc;
+    GstFlowReturn gstret;
 
     /* Return immediately if V4l2 streaming has not yet started. */
     if (!dev->is_streaming)
@@ -477,6 +512,14 @@ static int v4l2_process_data(struct v4l2_device *dev)
     }
 
     dev->dqbuf_count++;
+
+    /* Push v4l2 buffer data to gstreamer appsrc */
+    gstbuf = gst_buffer_new_allocate(NULL, dev->mem[0].length, NULL);
+    gst_buffer_fill(gstbuf, 0, dev->mem[0].start, dev->mem[0].length);
+    appsrc = gst_bin_get_by_name (GST_BIN (pipeline), "source");
+    g_signal_emit_by_name (appsrc, "push-buffer", gstbuf, &gstret);
+    gst_object_unref (appsrc);
+    gst_buffer_unref (gstbuf);
 
 #ifdef ENABLE_BUFFER_DEBUG
     printf("Dequeueing buffer at V4L2 side = %d\n", vbuf.index);
@@ -2048,6 +2091,52 @@ static void usage(const char *argv0)
     fprintf(stderr, " -v device	V4L2 Video Capture device\n");
 }
 
+GstElement* gst_init_appsrc_pipeline()
+{
+    GstElement *pipeline, *appsrc, *queue, *rtppay, *udpsink;
+    GstBus *bus;
+
+    /* setup appsrc pipeline */
+    pipeline = gst_pipeline_new ("pipeline");
+    appsrc = gst_element_factory_make ("appsrc", "source");
+    queue = gst_element_factory_make("queue", NULL);
+    rtppay = gst_element_factory_make ("rtpjpegpay", "payload");
+    udpsink = gst_element_factory_make ("udpsink", "udp_sink");
+
+    /* setup caps */
+    g_object_set (G_OBJECT (appsrc), "caps",
+        gst_caps_new_simple ("image/jpeg",
+                        "format", G_TYPE_STRING, "I420",
+                        "width", G_TYPE_INT, 1280,
+                        "height", G_TYPE_INT, 720,
+                        "framerate", GST_TYPE_FRACTION, 30, 1,
+                        NULL), NULL);
+    gst_bin_add_many (GST_BIN (pipeline), appsrc, queue, rtppay, udpsink, NULL);
+    gst_element_link_many (appsrc, queue, rtppay, udpsink, NULL);
+
+    /* setup appsrc */
+    g_object_set (G_OBJECT (appsrc),
+        "do-timestamp", TRUE,
+        "format", GST_FORMAT_TIME,
+        "is-live", TRUE, NULL);
+
+    /* setup queue */
+    g_object_set(G_OBJECT(queue), "leaky", 2, NULL);
+    g_object_set(G_OBJECT(queue), "max-size-time", 500 * GST_MSECOND, NULL);
+
+    /* setup udpsink */
+    g_object_set(G_OBJECT(udpsink), "clients", "192.168.2.169:1234", NULL);
+    g_object_set(G_OBJECT(udpsink), "sync", TRUE, NULL);
+
+    bus = gst_pipeline_get_bus (GST_PIPELINE (pipeline));
+    gst_bus_add_watch (bus, gst_bus_callback, NULL);
+    gst_object_unref (bus);
+
+    gst_element_set_state (pipeline, GST_STATE_PLAYING);
+
+    return pipeline;
+}
+
 int main(int argc, char *argv[])
 {
     struct uvc_device *udev;
@@ -2192,17 +2281,9 @@ int main(int argc, char *argv[])
             return 1;
     }
 
-    GstBuffer *gstbuf;
-    GstMemory *gstmem;
-
-    gstbuf = gst_buffer_new();
-
-    //FIXME AL: I see segfault when allocating memory. Why??
-    printf("Before allocating gst memory\n");
-    gstmem = gst_allocator_alloc(NULL, fmt.fmt.pix.sizeimage, NULL);
-    printf("After allocating gst memory\n");
-
-    gst_buffer_insert_memory(gstbuf, -1, gstmem);
+    /* Init appsrc pipeline that will push v4l2 data to udp sink */
+    gst_init (&argc, &argv);
+    GstElement *pipeline = gst_init_appsrc_pipeline();
 
     /* Open the UVC device. */
     ret = uvc_open(&udev, uvc_devname);
@@ -2341,7 +2422,7 @@ int main(int argc, char *argv[])
             uvc_video_process(udev);
         if (!dummy_data_gen_mode && !mjpeg_image)
             if (FD_ISSET(vdev->v4l2_fd, &fdsv))
-                v4l2_process_data(vdev);
+                v4l2_process_data(vdev, pipeline);
     }
 
     if (!dummy_data_gen_mode && !mjpeg_image && vdev->is_streaming) {

--- a/uvc-gadget.c
+++ b/uvc-gadget.c
@@ -2192,6 +2192,18 @@ int main(int argc, char *argv[])
             return 1;
     }
 
+    GstBuffer *gstbuf;
+    GstMemory *gstmem;
+
+    gstbuf = gst_buffer_new();
+
+    //FIXME AL: I see segfault when allocating memory. Why??
+    printf("Before allocating gst memory\n");
+    gstmem = gst_allocator_alloc(NULL, fmt.fmt.pix.sizeimage, NULL);
+    printf("After allocating gst memory\n");
+
+    gst_buffer_insert_memory(gstbuf, -1, gstmem);
+
     /* Open the UVC device. */
     ret = uvc_open(&udev, uvc_devname);
     if (udev == NULL || ret < 0)


### PR DESCRIPTION
OP#18328
- Added gstreamer appsrc that pushes v4l2 frames to udp sink
- Compiles and runs OK:
   - I'm able to see both USB and UDP streams from the same v4l2 source
- Problems:
   - Huge latency on UDP sink (around 2-3 sec)
   - Very low framerate on UDP sink (around 1 frame every 1-2 sec)

To test:
- On Rocam run: `./uvc-new -f 1 -r 1 -v <v4l2_video_node> -u <uvc_video_node>`
- On PC run:
   - for USB stream: `gst-launch-1.0 v4l2src device=<uvc_video_node> ! avdec_mjpeg ! videoconvert ! xvimagesink sync=false`
   - for UDP stream: `gst-launch-1.0 udpsrc port=1234 ! application/x-rtp,payload=26 ! rtpjpegdepay ! avdec_mjpeg ! videoconvert ! xvimagesink sync=false`